### PR TITLE
Drop support for `category.threshold` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ categories:
     lte: 30
   - name: m
     lte: 100
-    threshold: true
   - name: l
     lte: 500
   - name: xl

--- a/src/category-configuration.ts
+++ b/src/category-configuration.ts
@@ -5,7 +5,6 @@ export type Categories = Required<Pick<Configuration, 'categories'>>["categories
 
 /** Validates a group of categories and provides a categorization method. */
 export class CategoryConfiguration {
-  threshold: number
   private categories: Categories
 
   constructor(categories: Categories) {
@@ -49,22 +48,7 @@ export class CategoryConfiguration {
       )
     }
 
-    const thresholdCategories = sorted.filter((category) => category.threshold)
-    if (!thresholdCategories.length){
-      throw new Error(
-        "You must provide one category with a `threshold` value to act as the warning threshold"
-      )
-    }
-
-    if (thresholdCategories.length > 1) {
-      throw new Error(
-        "You can only specify one category with a `threshold` value, but we found at least two: " +
-        thresholdCategories.map((c) => c.name)
-      )
-    }
-
     this.categories = sorted
-    this.threshold = thresholdCategories[0].lte!
   }
 
   /**

--- a/src/config/default.yaml
+++ b/src/config/default.yaml
@@ -13,7 +13,6 @@ categories:
       color: 5d9801
   - name: medium
     lte: 100
-    threshold: true
     label:
       name: m
       description: Should be of average difficulty to review

--- a/src/config/schema.json
+++ b/src/config/schema.json
@@ -38,11 +38,6 @@
                         "description": "inclusive upper bound on the score that a pull request must have to be assigned this category",
                         "type": "number",
                         "inclusiveMinimum": 0
-                    },
-                    "threshold": {
-                        "description": "Whether or not this category marks the threshold above which we should warn about the diff being difficult to review",
-                        "type": "boolean"
-
                     }
                 },
                 "required": [

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -40,10 +40,6 @@ export interface Configuration {
      * inclusive upper bound on the score that a pull request must have to be assigned this category
      */
     lte?: number;
-    /**
-     * Whether or not this category marks the threshold above which we should warn about the diff being difficult to review
-     */
-    threshold?: boolean;
   }[];
   scoring?: {
     /**

--- a/src/score.ts
+++ b/src/score.ts
@@ -21,13 +21,6 @@ export class Score {
    */
   category?: ArrayElement<Categories>
   /**
-   * The threshold value for `result` above which the caller should consider
-   * emitting a warning that the changeset will be difficult to review.
-   * If this value is undefined, then either we encoutered an error when evaluating the formula
-   * or no categories were provided when the `addValue` method was called.
-   */
-  threshold?: number
-  /**
    * An error that we encountered when evaluating the formula on the changeset.
    * If this value is undefined, then no error was encountered during evaluation.
    */
@@ -53,7 +46,6 @@ export class Score {
     this.error = error
     this.result = undefined
     this.category = undefined
-    this.threshold = undefined
   }
 
   /**
@@ -66,7 +58,6 @@ export class Score {
     this.error = undefined
     this.result = value
     this.category = categories?.categorize(value)
-    this.threshold = categories?.threshold
   }
 
   /**
@@ -83,9 +74,7 @@ export class Score {
     return JSON.stringify(
       this,
       (key, value) => {
-        if (key == "category" && value) {
-          return { name: value.name, lte: value.lte }
-        } else if(value instanceof Map) {
+        if(value instanceof Map) {
           return [...value]
         } else {
           return value

--- a/test/category-configuration.test.ts
+++ b/test/category-configuration.test.ts
@@ -30,21 +30,5 @@ describe("CategoryConfiguration", () => {
         "You can only specify one category without an `lte` value, but we found at least two: large,xxl"
       )
     })
-
-    it("should error when it does not find a properly configured threshold category", () => {
-      const categories = [{ name: "smol" }]
-      expect(() => new CategoryConfiguration(categories)).to.throw(
-        Error,
-        "You must provide one category with a `threshold` value to act as the warning threshold"
-      )
-    })
-
-    it("should error when it finds more than one category configured as the threshold", () => {
-      const categories = [{ name: "smol", lte: 10, threshold: true }, { name: "large", threshold: true }]
-      expect(() => new CategoryConfiguration(categories)).to.throw(
-        Error,
-        "You can only specify one category with a `threshold` value, but we found at least two: smol,large"
-      )
-    })
   })
 })


### PR DESCRIPTION
The core library doesn't need to know about thresholds; that information can and should be configured in tools that consume this library.

This is related to https://github.com/lerebear/sizeup-action/issues/6.