### PR TITLE
Improve identification of single word lines

### DIFF
--- a/src/features/single-words.ts
+++ b/src/features/single-words.ts
@@ -10,7 +10,7 @@ export default class SingleWords extends Feature {
               change
                 .content
                 .split("\n")
-                .filter((line) => line.trim().match(/^\+\s*["'`,\w-]+\s*$/))
+                .filter((line) => line.trim().match(/^\+\s*(["'`]?)\b[\w-]+\b\1\S?$/))
                 .length
             )
           }

--- a/test/features/single-words.test.ts
+++ b/test/features/single-words.test.ts
@@ -14,7 +14,7 @@ describe("SingleWords", () => {
 
   describe("#evaluate", () => {
     it("should sum the number of lines containing just a single word across all files in the changeset", () => {
-      expect(feature.evaluate()).to.equal(6)
+      expect(feature.evaluate()).to.equal(8)
     })
   })
 })

--- a/test/fixtures/diffs/single-words.diff
+++ b/test/fixtures/diffs/single-words.diff
@@ -15,3 +15,6 @@ index 8aa27aa..fc65469 100644
 +wait 
 +`one`
 +   'minute'
++more:
++  " ever again"
++"please":


### PR DESCRIPTION
Specifically, this identifies common syntax for object/hash keys (e.g. "key:") as single words. This matches the behaviour of glortho/pr-size-helper-action, which this feature is modeled after.