### PR TITLE
Add comment recognition for Kotlin, XML, HTML and YAML files.

### DIFF
--- a/.projections.json
+++ b/.projections.json
@@ -1,0 +1,3 @@
+{
+  "src/*.ts": { "alternate": "test/{}.test.ts" }
+}

--- a/src/features/comments.ts
+++ b/src/features/comments.ts
@@ -22,8 +22,8 @@ export default class Comments extends Feature {
           continue
         }
 
-        const line = change.content.substring(1).trimStart()
-        if (line.startsWith(file.language.lineCommentStyle.start)) {
+        const line = change.content.substring(1).trim()
+        if (file.language.lineCommentStyle && line.startsWith(file.language.lineCommentStyle.start)) {
           sum++
           blockCommentLines = 0
         } else if (file.language.blockCommentStyle && line.startsWith(file.language.blockCommentStyle.start) && line.endsWith(file.language.blockCommentStyle.end)) {
@@ -31,7 +31,7 @@ export default class Comments extends Feature {
           blockCommentLines = 0
         } else if (file.language.blockCommentStyle && line.startsWith(file.language.blockCommentStyle.start)) {
           blockCommentLines++
-        } else if (file.language.blockCommentStyle && blockCommentLines > 0 && line.startsWith(file.language.blockCommentStyle.end)) {
+        } else if (file.language.blockCommentStyle && blockCommentLines > 0 && line.endsWith(file.language.blockCommentStyle.end)) {
           // We must check for block comment end _before_ we check for block comment continuation,
           // because the block comment continuation is frequently a substring of the block comment
           // end (e.g. in languages with C-style comments, "*" is a substring of "*/")

--- a/src/linguist.ts
+++ b/src/linguist.ts
@@ -110,6 +110,13 @@ export const TypeScript: Language = {
   ...cStyleComments,
 }
 
+export const YAML: Language = {
+  name: "YAML",
+  fileExtensions: ["yml", "yaml"],
+  ...pythonStyleComments,
+}
+
+
 export const SUPPORTED_LANGUAGES: Language[] = [
   CSharp,
   Go,
@@ -121,4 +128,5 @@ export const SUPPORTED_LANGUAGES: Language[] = [
   Rust,
   Swift,
   TypeScript,
+  YAML,
 ];

--- a/src/linguist.ts
+++ b/src/linguist.ts
@@ -74,6 +74,12 @@ export const JavaScript: Language = {
   ...cStyleComments,
 }
 
+export const Kotlin: Language = {
+  name: "Kotlin",
+  fileExtensions: ["kt", "kts"],
+  ...cStyleComments,
+}
+
 export const Python: Language = {
   name: "Python",
   fileExtensions: ["py"],
@@ -109,6 +115,7 @@ export const SUPPORTED_LANGUAGES: Language[] = [
   Go,
   Java,
   JavaScript,
+  Kotlin,
   Python,
   Ruby,
   Rust,

--- a/src/linguist.ts
+++ b/src/linguist.ts
@@ -17,7 +17,7 @@ export interface Language {
   /** The extensions used by files written in the language. */
   fileExtensions: string[]
   /** The style used for single-line comments. */
-  lineCommentStyle: LineCommentStyle
+  lineCommentStyle?: LineCommentStyle
   /** The style used for multi-line comments. */
   blockCommentStyle?: BlockCommentStyle
 }
@@ -41,13 +41,23 @@ interface BlockCommentStyle extends CommentStyle {
   end: string
 }
 
-const pythonStyleComments = {
-  lineCommentStyle: { start: "#" },
+export enum CommentStyleFamily {
+  C = "c",
+  HTML = "html",
+  Python = "python",
 }
 
 const cStyleComments = {
   lineCommentStyle: { start: "//" },
   blockCommentStyle: { start: "/*", continuation: "*", end: "*/"},
+}
+
+const htmlStyleComments = {
+  blockCommentStyle: { start: "<!--", continuation: "", end: "-->"},
+}
+
+const pythonStyleComments = {
+  lineCommentStyle: { start: "#" },
 }
 
 export const CSharp: Language = {
@@ -60,6 +70,12 @@ export const Go: Language = {
   name: "Go",
   fileExtensions: ["go"],
   ...cStyleComments,
+}
+
+export const HTML: Language = {
+  name: "HTML",
+  fileExtensions: ["htm", "html"],
+  ...htmlStyleComments,
 }
 
 export const Java: Language = {
@@ -110,6 +126,12 @@ export const TypeScript: Language = {
   ...cStyleComments,
 }
 
+export const XML: Language = {
+  name: "XML",
+  fileExtensions: ["xml"],
+  ...htmlStyleComments,
+}
+
 export const YAML: Language = {
   name: "YAML",
   fileExtensions: ["yml", "yaml"],
@@ -120,6 +142,7 @@ export const YAML: Language = {
 export const SUPPORTED_LANGUAGES: Language[] = [
   CSharp,
   Go,
+  HTML,
   Java,
   JavaScript,
   Kotlin,
@@ -128,5 +151,6 @@ export const SUPPORTED_LANGUAGES: Language[] = [
   Rust,
   Swift,
   TypeScript,
+  XML,
   YAML,
 ];

--- a/test/features/comments.test.ts
+++ b/test/features/comments.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai"
 import Changeset from "../../src/changeset"
 import Comments from "../../src/features/comments"
-import { TypeScript, JavaScript, Go, CSharp, Java, Rust, Swift, Python, Ruby, Kotlin} from "../../src/linguist"
+import { TypeScript, JavaScript, Go, CSharp, Java, Rust, Swift, Python, Ruby, Kotlin, YAML} from "../../src/linguist"
 import { loadCStyleCommentFixture, loadPythonStyleCommentFixture } from "../helpers/diff"
 
 describe("Comments", () => {
@@ -12,13 +12,25 @@ describe("Comments", () => {
   })
 
   describe("#evaluate", () => {
-    it("should sum the number of Python-style comments in added or modified lines in the changeset", () => {
-      const pythonStyleCommentLanguages = [
-        Ruby,
-        Python,
-      ]
+    const pythonStyleCommentLanguages = [
+      Ruby,
+      Python,
+      YAML,
+    ]
 
-      for (const lang of pythonStyleCommentLanguages) {
+    const cStyleCommentLanguages = [
+      CSharp,
+      Go,
+      Java,
+      JavaScript,
+      Kotlin,
+      Rust,
+      Swift,
+      TypeScript,
+    ]
+
+    for (const lang of pythonStyleCommentLanguages) {
+      it(`should sum the number of comments in modified lines of a ${lang.name} file`, () => {
         for (const ext of lang.fileExtensions) {
           const feature = new Comments(new Changeset({ diff: loadPythonStyleCommentFixture(ext) }))
           expect(feature.evaluate()).to.equal(
@@ -26,22 +38,11 @@ describe("Comments", () => {
             `expected comments to be recognized correctly for ${lang.name} in file extension ${ext}`
           )
         }
-      }
-    })
+      })
+    }
 
-    it("should sum the number of C-style comments in added or modified lines in the changeset", () => {
-      const cStyleCommentLanguages = [
-        CSharp,
-        Go,
-        Java,
-        JavaScript,
-        Kotlin,
-        Rust,
-        Swift,
-        TypeScript,
-      ]
-
-      for (const lang of cStyleCommentLanguages) {
+    for (const lang of cStyleCommentLanguages) {
+      it(`should sum the number of comments in modified lines of a ${lang.name} file`, () => {
         for (const ext of lang.fileExtensions) {
           const feature = new Comments(new Changeset({ diff: loadCStyleCommentFixture(ext) }))
           expect(feature.evaluate()).to.equal(
@@ -49,7 +50,7 @@ describe("Comments", () => {
             `expected comments to be recognized correctly for ${lang.name} in file extension ${ext}`
           )
         }
-      }
-    })
+      })
+    }
   })
 })

--- a/test/features/comments.test.ts
+++ b/test/features/comments.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai"
 import Changeset from "../../src/changeset"
 import Comments from "../../src/features/comments"
-import { TypeScript, JavaScript, Go, CSharp, Java, Rust, Swift, Python, Ruby} from "../../src/linguist"
+import { TypeScript, JavaScript, Go, CSharp, Java, Rust, Swift, Python, Ruby, Kotlin} from "../../src/linguist"
 import { loadCStyleCommentFixture, loadPythonStyleCommentFixture } from "../helpers/diff"
 
 describe("Comments", () => {
@@ -35,6 +35,7 @@ describe("Comments", () => {
         Go,
         Java,
         JavaScript,
+        Kotlin,
         Rust,
         Swift,
         TypeScript,

--- a/test/features/comments.test.ts
+++ b/test/features/comments.test.ts
@@ -1,8 +1,8 @@
 import { expect } from "chai"
 import Changeset from "../../src/changeset"
 import Comments from "../../src/features/comments"
-import { TypeScript, JavaScript, Go, CSharp, Java, Rust, Swift, Python, Ruby, Kotlin, YAML} from "../../src/linguist"
-import { loadCStyleCommentFixture, loadPythonStyleCommentFixture } from "../helpers/diff"
+import { TypeScript, JavaScript, Go, CSharp, Java, Rust, Swift, Python, Ruby, Kotlin, YAML, XML, HTML, CommentStyleFamily, Language} from "../../src/linguist"
+import { loadCommentFixture } from "../helpers/diff"
 
 describe("Comments", () => {
   describe(".variableName", () => {
@@ -12,41 +12,47 @@ describe("Comments", () => {
   })
 
   describe("#evaluate", () => {
-    const pythonStyleCommentLanguages = [
-      Ruby,
-      Python,
-      YAML,
+    const languageMatrix: [Language, CommentStyleFamily][] = [
+      [CSharp, CommentStyleFamily.C],
+      [Go, CommentStyleFamily.C],
+      [HTML, CommentStyleFamily.HTML],
+      [Java, CommentStyleFamily.C],
+      [JavaScript, CommentStyleFamily.C],
+      [Kotlin, CommentStyleFamily.C],
+      [Python, CommentStyleFamily.Python],
+      [Ruby, CommentStyleFamily.Python],
+      [Rust, CommentStyleFamily.C],
+      [Swift, CommentStyleFamily.C],
+      [TypeScript, CommentStyleFamily.C],
+      [XML, CommentStyleFamily.HTML],
+      [YAML, CommentStyleFamily.Python],
     ]
 
-    const cStyleCommentLanguages = [
-      CSharp,
-      Go,
-      Java,
-      JavaScript,
-      Kotlin,
-      Rust,
-      Swift,
-      TypeScript,
-    ]
+    for (const spec of languageMatrix) {
+      const lang = spec[0];
+      const commentFamily = spec[1];
 
-    for (const lang of pythonStyleCommentLanguages) {
-      it(`should sum the number of comments in modified lines of a ${lang.name} file`, () => {
-        for (const ext of lang.fileExtensions) {
-          const feature = new Comments(new Changeset({ diff: loadPythonStyleCommentFixture(ext) }))
-          expect(feature.evaluate()).to.equal(
-            4,
-            `expected comments to be recognized correctly for ${lang.name} in file extension ${ext}`
-          )
+      let numExpectedComments = 0;
+      switch(commentFamily) {
+        case CommentStyleFamily.C: {
+          numExpectedComments = 6;
+          break
         }
-      })
-    }
+        case CommentStyleFamily.HTML: {
+          numExpectedComments = 7;
+          break
+        }
+        case CommentStyleFamily.Python: {
+          numExpectedComments = 4;
+          break
+        }
+      }
 
-    for (const lang of cStyleCommentLanguages) {
       it(`should sum the number of comments in modified lines of a ${lang.name} file`, () => {
         for (const ext of lang.fileExtensions) {
-          const feature = new Comments(new Changeset({ diff: loadCStyleCommentFixture(ext) }))
+          const feature = new Comments(new Changeset({ diff: loadCommentFixture(commentFamily, ext) }))
           expect(feature.evaluate()).to.equal(
-            6,
+            numExpectedComments,
             `expected comments to be recognized correctly for ${lang.name} in file extension ${ext}`
           )
         }

--- a/test/fixtures/diffs/html-style-comment.diff
+++ b/test/fixtures/diffs/html-style-comment.diff
@@ -1,0 +1,28 @@
+diff --git a/lorem.ext b/lorem.ext
+index 70714bc..f0253cf 100644
+--- lorem.ext
++++ lorem.ext
+@@ -2,11 +2,21 @@
+ <html>
+
+    <head>
+-      <title>Using Comment Tag</title>
++      <title>This change is innocuous</title>
+    </head>
+
+    <body>
+-      <p>This is <comment>not</comment> Internet Explorer.</p>
++      <!-- This is single-line comment -->
++      <p>This is <comment>not</comment> Internet Explorer?</p>
++      <!-- this is
++         one type of
++       multi-line comment -->
++
++       <b> This is markup </b>
++
++      <!--
++         this is another type of multi-line comment
++      -->
+    </body>
+
+ </html>

--- a/test/helpers/diff.ts
+++ b/test/helpers/diff.ts
@@ -1,14 +1,11 @@
 import * as fs from "fs"
+import { CommentStyleFamily } from "../../src/linguist"
 
 export function loadFixture(name: string): string {
   return fs.readFileSync(`test/fixtures/diffs/${name}.diff`, "utf8")
 }
 
-export function loadPythonStyleCommentFixture(extension: string): string {
-  return fs.readFileSync(`test/fixtures/diffs/python-style-comment.diff`, "utf8").replace(/lorem\.ext/g, `lorem.${extension}`)
-}
+export function loadCommentFixture(style: CommentStyleFamily, extension: string) {
+  return fs.readFileSync(`test/fixtures/diffs/${style.toString().toLowerCase()}-style-comment.diff`, "utf8").replace(/lorem\.ext/g, `lorem.${extension}`)
 
-
-export function loadCStyleCommentFixture(extension: string): string {
-  return fs.readFileSync(`test/fixtures/diffs/c-style-comment.diff`, "utf8").replace(/lorem\.ext/g, `lorem.${extension}`)
 }


### PR DESCRIPTION
Closes #29
Closes #30
Closes #31
Closes #32
